### PR TITLE
Fix loading on Ruby 2.7

### DIFF
--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -23,7 +23,7 @@ module Blurhash
 
   module Unstable
     extend FFI::Library
-    ffi_lib File.join(File.expand_path(__dir__), '..', 'ext', 'blurhash', 'encode.' + RbConfig::CONFIG['DLEXT'])
+    ffi_lib File.join(File.expand_path(File.dirname(__FILE__)), '..', 'ext', 'blurhash', 'encode.' + RbConfig::CONFIG['DLEXT'])
     attach_function :blurHashForPixels, %i(int int int int pointer size_t), :string
   end
 

--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -23,7 +23,7 @@ module Blurhash
 
   module Unstable
     extend FFI::Library
-    ffi_lib File.join(File.expand_path(__dir__), 'encode.' + RbConfig::CONFIG['DLEXT'])
+    ffi_lib File.join(File.expand_path(__dir__), '..', 'ext', 'blurhash', 'encode.' + RbConfig::CONFIG['DLEXT'])
     attach_function :blurHashForPixels, %i(int int int int pointer size_t), :string
   end
 


### PR DESCRIPTION
Inspiration from https://github.com/akihikodaki/cld3-ruby/blob/master/lib/cld3.rb#L115

For some reason, the `.so` is built but not copied to `lib/` when using Ruby 2.7, so loading the gem fails at runtime