### PR TITLE
Fix support for Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ arch:
   - arm64
   - ppc64le
   - s390x
+addons:
+  apt:
+    packages:
+      - libmagick++-dev
 sudo: false
 language: ruby
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
+arch:
+  - amd64
+  - arm64
+  - ppc64le
+  - s390x
 sudo: false
 language: ruby
 rvm:
+  - 2.7.0
+  - 2.6.5
   - 2.6.1
 before_install: gem install bundler -v 2.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ rvm:
   - 2.7.0
   - 2.6.5
   - 2.6.1
-before_install: gem install bundler -v 2.0.1
+before_install: gem install bundler -v 2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ task :build => :compile
 
 Rake::ExtensionTask.new("blurhash") do |ext|
   ext.name = "encode"
+  ext.lib_dir = "lib/blurhash"
 end
 
 task :default => [:clobber, :compile, :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :build => :compile
 
 Rake::ExtensionTask.new("blurhash") do |ext|
   ext.name = "encode"
-  ext.lib_dir = "lib/blurhash"
+  ext.lib_dir = "ext/blurhash"
 end
 
 task :default => [:clobber, :compile, :spec]

--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -23,7 +23,7 @@ module Blurhash
 
   module Unstable
     extend FFI::Library
-    ffi_lib File.join(File.expand_path(__dir__), 'encode.' + RbConfig::CONFIG['DLEXT'])
+    ffi_lib File.join(File.expand_path(File.dirname(__FILE__)), '..', 'ext', 'blurhash', 'encode.' + RbConfig::CONFIG['DLEXT'])
     attach_function :blurHashForPixels, %i(int int int int pointer size_t), :string
   end
 


### PR DESCRIPTION
Solves the following issue on my Mastodon server (Ruby 2.7 on Arch linux arm64):

> LoadError: Could not open library '/home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/blurhash-0.1.3/lib/encode.so': /home/mastodon/live/vendor/bundle/ruby/2.7.0/gems/blurhash-0.1.3/lib/encode.so: cannot open shared object file: No such file or directory

I believe this occurs because Ruby 2.7 doesn't install gems in `lib/` anymore, so the extension should be loaded from `ext/` instead, like is done in https://github.com/akihikodaki/cld3-ruby/blob/master/lib/cld3.rb#L115

This is a discrepancy from the `Rake::ExtensionTask` mechanism which by default seem to install in `lib/` and *not* in `ext/`, so changed the config accordingly for the tests to pass.

The widening of test targets in `.travis.yml` is not necessary, we can do without it.