### PR TITLE
Relax ffi gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    blurhash (0.1.3)
-      ffi (~> 1.10.0)
+    blurhash (0.1.4)
+      ffi (~> 1.10)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    ffi (1.10.0)
+    ffi (1.12.2)
     rake (13.0.1)
     rake-compiler (1.0.7)
       rake

--- a/blurhash.gemspec
+++ b/blurhash.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions    = ['ext/blurhash/extconf.rb']
 
-  spec.add_dependency 'ffi', '~> 1.10.0'
+  spec.add_dependency 'ffi', '~> 1.10'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
The `ffi` gem should not have breaking changes without changing major version.
Currently the dependency only allows FFI `1.10.*` but this should be relaxed to allow any `1.*` versions.

This is a problem as other gems might have other FFI requirements (for example requiring FFI > 1.12 because a new feature has been introduced) and this prevent using both gems in the same project.

Tests are passing locally on my mac with both FFI 1.10.0 & 1.12.2 (latest version).
