### PR TITLE
Updates ffi dependency to fix Ruby3 warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     blurhash (0.1.4)
-      ffi (~> 1.10)
+      ffi (~> 1.12)
 
 GEM
   remote: https://rubygems.org/
@@ -39,4 +39,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.1
+   2.2.14

--- a/blurhash.gemspec
+++ b/blurhash.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions    = ['ext/blurhash/extconf.rb']
 
-  spec.add_dependency 'ffi', '~> 1.10'
+  spec.add_dependency 'ffi', '~> 1.12'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
This PR updates the `ffi` dependency to avoid deprecation warnings on ruby2.7
