### PR TITLE
Do not link to libruby when the native library is built by mkmf and used for FFI

### DIFF
--- a/ext/blurhash/extconf.rb
+++ b/ext/blurhash/extconf.rb
@@ -1,4 +1,8 @@
 require 'mkmf'
 
 $CFLAGS += ' -std=c99 -lm'
+
+# Don't link to libruby
+$LIBRUBYARG = nil
+
 create_makefile 'encode'


### PR DESCRIPTION
* Otherwise we end up with errors of not finding libruby.
* Same approach as https://github.com/sass/sassc-ruby/blob/4fce2b635c/ext/extconf.rb#L72-L73
* It is also better to not depend on libruby here for clarity that there is no dependency on the C API and not load it unnecessarily (if it'd worked).

This makes the gem work and the test suite pass on TruffleRuby, while before it would fail like:
```
$ ruby -rblurhash -e0
/home/eregon/.rubies/truffleruby-dev/lib/gems/gems/ffi-1.15.4/lib/ffi/library.rb:145:in `block in ffi_lib': libgraalvm-llvm.so.1: cannot open shared object file: No such file or directory (com.oracle.truffle.nfi.backend.libffi.NFIUnsatisfiedLinkError) (LoadError)
Translated to internal error
...
```

The same situation might happen with CRuby and `--enable-shared`, although that depends on the linking flags provided by CRuby.