### PR TITLE
Use portable integer type

### DIFF
--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -5,7 +5,7 @@ require 'ffi'
 
 module Blurhash
   def self.encode(width, height, pixels, x_comp: 4, y_comp: 3)
-    FFI::MemoryPointer.new(:u_int8_t, pixels.size) do |p|
+    FFI::MemoryPointer.new(:uint8, pixels.size) do |p|
       p.write_array_of_uint8(pixels)
       return Unstable.blurHashForPixels(x_comp, y_comp, width, height, p, width * 3)
     end


### PR DESCRIPTION
This fixes an issue I ran into on illumos (SmartOS) where the `u_int8_t` type could not be resolved:


```
 TypeError (unable to resolve type 'u_int8_t'):
   
 lib/paperclip/blurhash_transcoder.rb:11:in `make'
 lib/paperclip/attachment_extensions.rb:21:in `block in post_process_style'
 lib/paperclip/attachment_extensions.rb:20:in `each'
 lib/paperclip/attachment_extensions.rb:20:in `inject'
 lib/paperclip/attachment_extensions.rb:20:in `post_process_style'
 app/controllers/api/v2/media_controller.rb:5:in `create'
 app/controllers/concerns/localized.rb:11:in `set_locale'
 lib/mastodon/rack_middleware.rb:9:in `call'
```