### PR TITLE
Load binary library from /lib/ instead of ../ext/blurhash/

### DIFF
--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -23,7 +23,7 @@ module Blurhash
 
   module Unstable
     extend FFI::Library
-    ffi_lib File.join(File.expand_path(File.dirname(__FILE__)), '..', 'ext', 'blurhash', 'encode.' + RbConfig::CONFIG['DLEXT'])
+    ffi_lib File.join(File.expand_path(File.dirname(__FILE__)), 'encode.' + RbConfig::CONFIG['DLEXT'])
     attach_function :blurHashForPixels, %i(int int int int pointer size_t), :string
   end
 


### PR DESCRIPTION
RubyGems started to clean built artifacts after building extensions since Ruby 3.2.0: https://github.com/rubygems/rubygems/pull/6133

Related: https://github.com/rubygems/rubygems/issues/6205

I have confirmed that the lines below works in an empty directory with `v` being 2.7.7, 3.0.5, 3.1.3, 3.2.0-rc1, and 3.2.0.

```
rbenv local $v
bundle init
bundle add blurhash --git=https://github.com/zunda/blurhash.git --branch=use-so-under-lib
bundle exec ruby -rblurhash -e 'puts Blurhash::VERSION'
```