### PR TITLE
Remove FFI dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    blurhash (0.1.5)
+    blurhash (0.1.6)
       ffi (~> 1.14)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
-    ffi (1.14.2)
+    ffi (1.15.5)
     rake (13.0.3)
     rake-compiler (1.1.1)
       rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,11 @@ PATH
   remote: .
   specs:
     blurhash (0.1.6)
-      ffi (~> 1.14)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
-    ffi (1.15.5)
     rake (13.0.3)
     rake-compiler (1.1.1)
       rake

--- a/Rakefile
+++ b/Rakefile
@@ -8,8 +8,7 @@ require "rake/extensiontask"
 task :build => :compile
 
 Rake::ExtensionTask.new("blurhash") do |ext|
-  ext.name = "encode"
-  ext.lib_dir = "ext/blurhash"
+  ext.name = "blurhash_ext"
 end
 
 task :default => [:clobber, :compile, :spec]

--- a/blurhash.gemspec
+++ b/blurhash.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.extensions    = ['ext/blurhash/extconf.rb']
 
-  spec.add_dependency 'ffi', '~> 1.14'
-
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rake-compiler'

--- a/ext/blurhash/encode.c
+++ b/ext/blurhash/encode.c
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <math.h>
+#include <ruby.h>
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -134,4 +135,23 @@ static char *encode_int(int value, int length, char *destination) {
 		*destination++ = characters[digit];
 	}
 	return destination;
+}
+
+VALUE rb_blur_hash_for_pixels(VALUE m, VALUE x_comp, VALUE y_comp, VALUE width, VALUE height, VALUE p)
+{
+    const char * buf = blurHashForPixels(NUM2INT(x_comp),
+            NUM2INT(y_comp),
+            NUM2INT(width),
+            NUM2INT(height),
+            (uint8_t *)StringValuePtr(p),
+            NUM2INT(width) * 3);
+
+    return rb_str_new2(buf);
+}
+
+void Init_blurhash_ext()
+{
+    VALUE mBlurhash = rb_define_module("Blurhash");
+    VALUE mUnstable = rb_define_module_under(mBlurhash, "Unstable");
+    rb_define_singleton_method(mUnstable, "blurHashForPixels", rb_blur_hash_for_pixels, 5);
 }

--- a/ext/blurhash/extconf.rb
+++ b/ext/blurhash/extconf.rb
@@ -5,4 +5,4 @@ $CFLAGS += ' -std=c99 -lm'
 # Don't link to libruby
 $LIBRUBYARG = nil
 
-create_makefile 'encode'
+create_makefile 'blurhash_ext'

--- a/ext/blurhash/extconf.rb
+++ b/ext/blurhash/extconf.rb
@@ -2,7 +2,4 @@ require 'mkmf'
 
 $CFLAGS += ' -std=c99 -lm'
 
-# Don't link to libruby
-$LIBRUBYARG = nil
-
 create_makefile 'blurhash_ext'

--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -5,10 +5,8 @@ require 'ffi'
 
 module Blurhash
   def self.encode(width, height, pixels, x_comp: 4, y_comp: 3)
-    FFI::MemoryPointer.new(:u_int8_t, pixels.size) do |p|
-      p.write_array_of_uint8(pixels)
-      return Unstable.blurHashForPixels(x_comp, y_comp, width, height, p, width * 3)
-    end
+    p = pixels.pack("C#{pixels.size}")
+    return Unstable.blurHashForPixels(x_comp, y_comp, width, height, p, width * 3)
   end
 
   def self.components(str)

--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 require 'blurhash/version'
-require 'ffi'
+require 'blurhash_ext'
 
 module Blurhash
   def self.encode(width, height, pixels, x_comp: 4, y_comp: 3)
     p = pixels.pack("C#{pixels.size}")
-    return Unstable.blurHashForPixels(x_comp, y_comp, width, height, p, width * 3)
+    return Unstable.blurHashForPixels(x_comp, y_comp, width, height, p)
   end
 
   def self.components(str)
@@ -17,12 +17,6 @@ module Blurhash
     return if str.size != 4 + 2 * x_comp * y_comp
 
     [x_comp, y_comp]
-  end
-
-  module Unstable
-    extend FFI::Library
-    ffi_lib File.join(File.expand_path(File.dirname(__FILE__)), '..', 'ext', 'blurhash', 'encode.' + RbConfig::CONFIG['DLEXT'])
-    attach_function :blurHashForPixels, %i(int int int int pointer size_t), :string
   end
 
   module Base83


### PR DESCRIPTION
This PR exposes Blurhash via the C extension API.  The upside is that we can remove the FFI dependency.  This should also fix #19 though I admit it's less surgical.