### PR TITLE
Check pixels array size

### DIFF
--- a/lib/blurhash.rb
+++ b/lib/blurhash.rb
@@ -5,6 +5,8 @@ require 'blurhash_ext'
 
 module Blurhash
   def self.encode(width, height, pixels, x_comp: 4, y_comp: 3)
+    raise 'Pixels array has wrong size' if pixels.size != width * height * 3
+
     p = pixels.pack("C#{pixels.size}")
     return Unstable.blurHashForPixels(x_comp, y_comp, width, height, p)
   end

--- a/spec/blurhash_spec.rb
+++ b/spec/blurhash_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Blurhash do
       pixels = File.read(File.join(__dir__, 'fixtures', 'test.bin')).unpack('C*')
       expect(Blurhash.encode(204, 204, pixels)).to eq 'LFE.@D9F01_2%L%MIVD*9Goe-;WB'
     end
+
+    it 'raises if pixels array has wrong size' do
+      expect { Blurhash.encode(204, 204, [0, 1, 2]) }.to raise_error(RuntimeError, 'Pixels array has wrong size')
+    end
   end
 
   describe '.components' do


### PR DESCRIPTION
Add check for pixels array size. Passing a too short array may cause segmentation fault.

Fixes #23.